### PR TITLE
Bound the api database connection pool

### DIFF
--- a/base/api/configmap.yaml
+++ b/base/api/configmap.yaml
@@ -12,6 +12,8 @@ data:
       database: {{.DB_DATABASE | default "zan"}}
       ca_cert: {{.DB_CA_CERT | default ""}}
       automigrate: true
+      max_open_conns: {{.DB_MAX_OPEN_CONNS | default "5"}}
+      max_idle_conns: {{.DB_MAX_IDLE_CONNS | default "2"}}
     discord:
       webhooks:
         pending_feedback: {{.DISCORD_WEBHOOK_PENDING_FEEDBACK}}


### PR DESCRIPTION
The api pool is unbounded in effect: pkg/database defaults to MaxOpenConns 50 / MaxIdleConns 10, and nothing in the config could override it. That is far past need for this facility, which served ~25 browser requests a day over the last six weeks, and it competes for max_connections on a database server shared with every other VATUSA service.

Set 5 open / 2 idle, overridable via DB_MAX_OPEN_CONNS and DB_MAX_IDLE_CONNS.

Requires the matching adh-partnership/api change adding max_open_conns and max_idle_conns to ConfigDatabase. Until that image ships these keys are inert rather than harmful -- ParseConfig uses a non-strict yaml.Unmarshal, so the running build ignores unknown fields.