### PR TITLE
Bound the ids-backend database connection pool

### DIFF
--- a/overlays/vatusa/ids/configmap.yaml
+++ b/overlays/vatusa/ids/configmap.yaml
@@ -24,6 +24,8 @@ data:
       database_name: idsv2 # database name
       auto_migrate: true # auto migrate database on startup
       CACert: "" # path to CA certificate for TLS connection
+      max_open_conns: 5 # connection pool ceiling; package default is 50
+      max_idle_conns: 2 # idle connections kept open; package default is 10
 
     facility:
       identifier: ZAN # FAA Facility Identifier


### PR DESCRIPTION
internal/database defaults to MaxOpenConns 50 / MaxIdleConns 10, so ids-backend could reserve 50 connections on a MySQL server shared with every other VATUSA service. Its actual load is roughly 7.8k statements a day.

Set 5 open / 2 idle.

Requires adh-partnership/ids#18, which adds max_open_conns and max_idle_conns to the database config. Until that image ships these keys are inert rather than harmful -- ParseConfig uses a non-strict sigs.k8s.io/yaml Unmarshal, so the running build ignores unknown fields.